### PR TITLE
Update book.tex

### DIFF
--- a/book.tex
+++ b/book.tex
@@ -4,7 +4,7 @@
 \usepackage[pass]{geometry}
 
 \usepackage{graphicx}
-\usepackage[pass]{float}
+\usepackage{float}
 \graphicspath{{images/}}
 
 \usepackage[utf8]{inputenc}


### PR DESCRIPTION
Removed erroneous [pass] option for `float' package call (sorry for that).
